### PR TITLE
Add archive script to generate single zip snapshot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,16 @@
+node_modules/
+release/
+dist/
+dist-electron/
+.DS_Store
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.pnpm-debug.log*
+.env
+.env.*
+.idea/
+.vscode/
+*.log
+*.zip
+!.github/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
 # TurkceDerslik
 8. Sınıf Türkçe Konu Anlatım ve Sınava Hazırlık Uygulaması
+
+## Güncel Tek Dosya Arşivi Nasıl Oluşturulur?
+
+Dal (branch) yapısıyla uğraşmadan projenin son hâlini tek bir dosya olarak almak için `bundle:archive` komutunu kullanabilirsiniz. Komut, mevcut dalın en güncel hâlini `release/` klasörü içinde `.zip` dosyası olarak üretir.
+
+```bash
+npm install
+npm run bundle:archive
+```
+
+Komut tamamlandığında terminalde oluşan dosya yolunu göreceksiniz. Bu `.zip` dosyası tüm proje dosyalarını içerir ve başka bir yerde açılarak kullanılabilir.

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "typecheck": "tsc --noEmit",
     "build": "vite build",
     "preview": "vite preview",
-    "package": "npm run build && electron-builder"
+    "package": "npm run build && electron-builder",
+    "bundle:archive": "node scripts/create-archive.mjs"
   },
   "devDependencies": {
     "@types/node": "^24.5.2",

--- a/scripts/create-archive.mjs
+++ b/scripts/create-archive.mjs
@@ -1,0 +1,26 @@
+#!/usr/bin/env node
+import { execSync } from 'node:child_process';
+import { existsSync, mkdirSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const runCommand = (command) => execSync(command, { stdio: 'pipe' }).toString().trim();
+
+const ensureReleaseDir = (dir) => {
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true });
+  }
+};
+
+const releaseDir = resolve('release');
+ensureReleaseDir(releaseDir);
+
+const branchName = runCommand('git rev-parse --abbrev-ref HEAD');
+const shortSha = runCommand('git rev-parse --short HEAD');
+const archiveName = `turkce-derslik-${branchName}-${shortSha}.zip`;
+const outputPath = resolve(releaseDir, archiveName);
+
+const archiveCommand = `git archive --format=zip --output="${outputPath}" HEAD`;
+execSync(archiveCommand, { stdio: 'inherit' });
+
+console.log(`\n✅ Arşiv hazır: ${outputPath}`);
+console.log('Bu dosya mevcut dalın en güncel hâlini içerir.');


### PR DESCRIPTION
## Summary
- add a reusable script that creates a ZIP archive of the current branch for easy sharing
- document how to produce the single-file archive in the README
- ignore build artifacts and release archives in version control

## Testing
- npm run bundle:archive

------
https://chatgpt.com/codex/tasks/task_e_68dc01a768288326a882f14a15b781be